### PR TITLE
Fixes `ValueError: Namespace GnomeKeyring not available`

### DIFF
--- a/ppa_copy_packages.py
+++ b/ppa_copy_packages.py
@@ -26,7 +26,7 @@ try:
     # produced by Launchpad.login_with() on Ubuntu 15.10 (+ gnome3-staging PPA)
     import gi
     gi.require_version('GnomeKeyring', '1.0')
-except ImportError:
+except (ImportError, ValueError):
     pass
 
 


### PR DESCRIPTION
On Ubuntu Focal, I get this error:

```
➜ ppa-copy-packages -O benjaoming -N lcrs -p lcrs2 -s trusty -t xenial bionic eoan focal groovy
Traceback (most recent call last):
  File "/usr/local/bin/ppa-copy-packages", line 5, in <module>
    from ppa_copy_packages import main
  File "/usr/local/lib/python3.8/dist-packages/ppa_copy_packages.py", line 28, in <module>
    gi.require_version('GnomeKeyring', '1.0')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace GnomeKeyring not available
```